### PR TITLE
Mod：渲染移动端页面时根据front-matter中设置的toc变量控制文章页内toc显示，footer页脚下方的ul居中(user agent stylesheet)

### DIFF
--- a/layout/post.ejs
+++ b/layout/post.ejs
@@ -14,9 +14,11 @@
                 </div>
             </header>
             <div class="kratos-post-content">
-                <div class="kratos-post-inner-toc">
-                    <%- toc(page.content) %>
-                </div>
+                <% if (page.toc) { %>
+                    <div class="kratos-post-inner-toc">
+                        <%- toc(page.content) %>
+                    </div>
+                <% } %>
                 <hr />
                 <%- page.content %>
             </div>

--- a/source/css/kratosr.css
+++ b/source/css/kratosr.css
@@ -398,8 +398,10 @@ td,th {padding:.2em 1em;border: 1px solid lightblue;}
 @media(min-width:992px){#footer .col-md-offset-3{margin-left:10%}#footer .col-md-6{width:80%}}
 #footer li{letter-spacing:1px;font-size:14px;text-transform:uppercase;display: inline-block}
 #footer li a{color:rgba(255,255,255,.5)}
+#footer .kratos-social-icons {padding-left: 0}
 #footer .kratos-social-icons li a{padding:4px 14px;text-decoration:none}
 #footer .kratos-social-icons li a i{font-size:36px}
+#footer .kratos-copyright{padding-left: 0}
 #footer .kratos-copyright{list-style: none}
 #footer .kratos-copyright li{color:rgba(255,255,255,.3);line-height:1;margin-left:1em;font-size:14px}
 @media screen and (max-width: 550px){#footer .kratos-copyright li{display:block;margin-top:1em}}


### PR DESCRIPTION
- 渲染移动端页面时，现在能根据 front-matter 中设置的 toc 变量控制文章页内 toc 显示(未修改之前，设置 toc: false，移动端还是会显示 toc );
- footer 页脚下方的 ul 居中 (user agent stylesheet 默认的 padding-inline-start: 40px; 样式导致无法正常居中)