### PR TITLE
Fix：修复了一个 pjax Bug，该 Bug 导致在点击浏览器后退按钮时 toc 显示异常

### DIFF
--- a/source/js/pjax.js
+++ b/source/js/pjax.js
@@ -1,5 +1,5 @@
 $(function() {
-    var ajx_main = '#main',
+    var row_content = '#kratos-blog-post .row';
     theTop = notMobile ? $("#kratos-blog-post").offset().top-40 : 0;
     function reload_func() {
         $(this).pjax_reload();
@@ -12,7 +12,7 @@ $(function() {
             if (typeof e.state.html === 'undefined') {
                 ajax(e.state.url, false);
             } else {
-                $(ajx_main).html( e.state.html );
+                $(row_content).html( e.state.html );
             }
             window.load = reload_func();
         }
@@ -24,24 +24,23 @@ $(function() {
                 history.replaceState({
                     url: location.href,
                     title: document.title,
-                    html: $(document).find(ajx_main).html()
+                    html: $(document).find(row_content).html()
                     }, document.title, location.href);
                 $("body,html").animate({scrollTop:theTop}, 600);
                 NProgress.start();
             },
             success: function(data) {
-                if (typeof $(data).find(ajx_main).html() === 'undefined') {
+                if (typeof $(data).find(row_content).html() === 'undefined') {
                     location.href = reqUrl;
                 } else {
-                    $(ajx_main).html($(data).find(ajx_main).html());
-                    $('#kratos-widget-area').html($(data).find('#kratos-widget-area').html());
+                    $(row_content).html($(data).find(row_content).html());
                 }
                 document.title = $(data).filter("title").text();
                 if (needPushState) {
                     window.history.pushState({
                         url: reqUrl,
                         title: $(data).filter("title").text(),
-                        html: $(data).find(ajx_main).html()
+                        html: $(data).find(row_content).html()
                     }, $(data).filter("title").text(), reqUrl);
                 }
             },


### PR DESCRIPTION

### 问题
修复了一个 pjax Bug，该 Bug 导致在点击浏览器后退按钮时 about widget 会显示之前文章详细页面的 toc ，而不是个人简介 slogan。

### 复现
从带有 toc 摘录的文章详情页，点击浏览器回退按钮回到首页(或者其他显示个人简介的页面)，会出现上述问题，参见下方图片。

### 修复
- [x] 已在 pjax.js 中修复

### 参考
![微信截图_20200627111926](https://user-images.githubusercontent.com/22054842/85913513-16644100-b868-11ea-85af-0c8ca712e5cb.png)