### PR TITLE
fix: archives articles time tag overlap

### DIFF
--- a/layout/archive.ejs
+++ b/layout/archive.ejs
@@ -47,29 +47,31 @@
                                 <a href="<%- url_for(config.root + config.archive_dir + '/' + year + '/') %>"><h2 class="archive-year"><%- year %></h2></a>
                               </div>
                             <% } %>
-                            <article class="post" itemscope>
-                              <header class="post-header">
-                                <h3 class="post-title">
-                                  <% if (post.link) { %>
-                                    <a class="post-title-link post-title-link-external" target="_blank" href="<%- url_for(post.link) %>" itemprop="url">
-                                      <%- post.title %>
-                                      <i class="fa fa-external-link"></i>
-                                    </a>
-                                  <% } else { %>
-                                      <a class="post-title-link" href="<%- url_for(post.path) %>" itemprop="url">
-                                        <span itemprop="name"><%- post.title %></span>
+                            <% if (post.title) { %>
+                              <article class="post" itemscope>
+                                <header class="post-header">
+                                  <h3 class="post-title">
+                                    <% if (post.link) { %>
+                                      <a class="post-title-link post-title-link-external" target="_blank" href="<%- url_for(post.link) %>" itemprop="url">
+                                        <%- post.title %>
+                                        <i class="fa fa-external-link"></i>
                                       </a>
-                                  <% } %>
-                                </h3>
-                                <div class="post-meta">
-                                  <time class="post-time" itemprop="dateCreated"
-                                        datetime="<%- moment(post.date).format() %>"
-                                        content="<%- date(post.date, config.date_format) %>" >
-                                    <%- date(post.date, 'MM-DD') %>
-                                  </time>
-                                </div>
-                              </header>
-                            </article>
+                                    <% } else { %>
+                                        <a class="post-title-link" href="<%- url_for(post.path) %>" itemprop="url">
+                                          <span itemprop="name"><%- post.title %></span>
+                                        </a>
+                                    <% } %>
+                                  </h3>
+                                  <div class="post-meta">
+                                    <time class="post-time" itemprop="dateCreated"
+                                          datetime="<%- moment(post.date).format() %>"
+                                          content="<%- date(post.date, config.date_format) %>" >
+                                      <%- date(post.date, 'MM-DD') %>
+                                    </time>
+                                  </div>
+                                </header>
+                              </article>
+                            <% } %>
                           <% }) %>
                         </div>
                       </div>


### PR DESCRIPTION
### 问题

在归档页，当有小日志文章时，也会生成归档文章列表项，造成时间重叠显示。 

### 修复
fix：生成归档页时，将未设置 title 属性的文章即小日志文章排除，不进行归档生成。

### 参考
![tag-overlap.png](https://i.loli.net/2020/09/13/H985pEyeQlAYgkb.png)
