### PR TITLE
fix: Javascript date is invalid on iOS

### DIFF
--- a/_config.yml.example
+++ b/_config.yml.example
@@ -107,7 +107,7 @@ search:
 jsconfig:
   main:
     picCDN: false
-    createTime: "1970-01-01 00:00:00"
+    createTime: "1970/01/01 00:00:00"
     donateBtn: "支持我~"
     scanNotice: "扫一扫，好不好？"
     qr_alipay: "/images/alipayqr.webp"


### PR DESCRIPTION
### Problem

Javascript date is invalid on iOS, which causes the creation time to appear as NaN.

![](https://i.loli.net/2020/11/28/VQBlL9wqHJEjNFu.jpg)

### Fix

Just use `YYYY/MM/DD HH:MM:SS` format that works for both IOS and Android.

### Reference
- Javascript date is invalid on iOS, see https://stackoverflow.com/questions/13363673/javascript-date-is-invalid-on-ios
