### PR TITLE
fix: Deprecated highlight.enable configuration

### DIFF
--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -60,7 +60,7 @@
     <%- css_theme_cdn('css/kr-color-dark.min.css', {id: "darkmode-css", media:"(prefers-color-scheme: dark)"}) %>
     <%- js_theme_cdn('js/kr-dark.min.js') %>
   <% } %>
-  <% if (config.highlight && config.highlight.enable && theme.highlight_theme) { %>
+  <% if (config.highlight && config.highlight.enable !== false && theme.highlight_theme) { %>
     <%- css_theme_cdn(`css/highlight/${theme.highlight_theme || 'night-eighties'}.min.css`, {id: "highlight-css", media:"all"}) %>
   <% } %>
   <%- css_npm_cdn('font-awesome', 'css/font-awesome.min.css', {id:"fontawe-css", media:"all"}) %>


### PR DESCRIPTION
在Hexo v7.0.0（2023-10-31）及以上版本中highlight.enable已被弃用，默认配置文件已不包含该配置项。