### PR TITLE
fix: wrong link for OpenGraph image tag

### DIFF
--- a/layout/_partial/head.ejs
+++ b/layout/_partial/head.ejs
@@ -37,8 +37,17 @@
   <% } %>
   <%- open_graph({
     image: (function(){
-      const image_path = page.cover ? page.path + page.cover : theme.site_logo;
-      return image_path ? full_url_for(image_path) : null;
+      const cover = page.cover;
+      if (cover) {
+        if (/^(#|\/\/|http(s)?:)/.test(cover)) {
+          return cover;
+        }
+        const coverPath = cover.startsWith('/') ? 
+          cover : 
+          page.path.replace(/(\/index)?\.html?$/, '') + '/' + cover;
+        return full_url_for(coverPath);
+      }
+      return null;
     })(),
     // twitter_site: theme.contact.twitter ? "@" + theme.contact.twitter : null,
     title


### PR DESCRIPTION
使用绝对路径时，OpenGraph image 标签的链接错误。

处理逻辑是从这里偷的：

https://github.com/Candinya/Kratos-Rebirth/blob/aa59401d68a10fbe4419054b0d93dedc2fe386c4/layout/_index_style/half.ejs#L7-L15